### PR TITLE
feat(auth): include baseSalary in JWT payload

### DIFF
--- a/domain/model/src/main/java/co/com/pragma/crediya/model/jwt/Jwt.java
+++ b/domain/model/src/main/java/co/com/pragma/crediya/model/jwt/Jwt.java
@@ -1,6 +1,7 @@
 package co.com.pragma.crediya.model.jwt;
 
+import java.math.BigDecimal;
 import java.util.List;
 
-public record Jwt(String subject, List<String> roles, String identificationNumber) {
+public record Jwt(String subject, List<String> roles, String identificationNumber, BigDecimal baseSalary) {
 }

--- a/infrastructure/driven-adapters/jwt/src/main/java/co/com/pragma/crediya/jwt/JwtProviderAdapter.java
+++ b/infrastructure/driven-adapters/jwt/src/main/java/co/com/pragma/crediya/jwt/JwtProviderAdapter.java
@@ -13,10 +13,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import javax.crypto.SecretKey;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.math.BigDecimal;
+import java.util.*;
 
 @Component
 @RequiredArgsConstructor
@@ -36,8 +34,9 @@ public class JwtProviderAdapter implements JwtProviderPort {
         String subject = extractSubject(claims);
         List<String> roles = extractRole(claims);
         String identificationNumber = extractIdentificationNumber(claims);
+        BigDecimal baseSalary = extractBaseSalary(claims);
 
-        return new Jwt(subject, roles, identificationNumber);
+        return new Jwt(subject, roles, identificationNumber, baseSalary);
     }
 
     private String buildToken(User user, long expiration) {
@@ -66,6 +65,7 @@ public class JwtProviderAdapter implements JwtProviderPort {
         Map<String, Object> claims = new HashMap<>();
         claims.put(UserFieldNames.ROLES, List.of(user.role().name()));
         claims.put(UserFieldNames.IDENTIFICATION_NUMBER, user.identificationNumber());
+        claims.put(UserFieldNames.BASE_SALARY, user.baseSalary());
         return claims;
     }
 
@@ -87,11 +87,18 @@ public class JwtProviderAdapter implements JwtProviderPort {
 
     @SuppressWarnings("unchecked")
     private List<String> extractRole(Claims claims) {
-        return (List<String>) claims.get(UserFieldNames.ROLES);
+        Object value = claims.get(UserFieldNames.ROLES);
+        return value != null ? (List<String>) value : Collections.emptyList();
     }
 
     private String extractIdentificationNumber(Claims claims) {
-        return claims.get(UserFieldNames.IDENTIFICATION_NUMBER).toString();
+        Object value = claims.get(UserFieldNames.IDENTIFICATION_NUMBER);
+        return value != null ? value.toString() : "";
+    }
+
+    private BigDecimal extractBaseSalary(Claims claims) {
+        Object value = claims.get(UserFieldNames.BASE_SALARY);
+        return value != null ? new BigDecimal(value.toString()) : BigDecimal.ZERO;
     }
 
     private String extractSubject(Claims claims) {

--- a/infrastructure/driven-adapters/jwt/src/test/java/co/com/pragma/crediya/jwt/JwtProviderAdapterTest.java
+++ b/infrastructure/driven-adapters/jwt/src/test/java/co/com/pragma/crediya/jwt/JwtProviderAdapterTest.java
@@ -57,6 +57,8 @@ class JwtProviderAdapterTest {
         assertEquals(jwt.roles(), List.of(user.role().name()));
 
         assertThat(jwt.identificationNumber()).isEqualTo(user.identificationNumber());
+
+        assertThat(jwt.baseSalary()).isEqualTo(user.baseSalary());
     }
 
 }


### PR DESCRIPTION
- Update Jwt record to include baseSalary
- Update JwtProviderAdapter to extract and include baseSalary from Claims
- Add baseSalary to JWT claims when building token
- Ensure extraction methods handle null values safely
- Update JwtProviderAdapterTest to verify baseSalary is correctly populated