### PR TITLE
feat(auth): migrate secrets to AWS Secrets Manager

### DIFF
--- a/applications/app-service/build.gradle
+++ b/applications/app-service/build.gradle
@@ -1,6 +1,9 @@
 apply plugin: 'org.springframework.boot'
 
 dependencies {
+	implementation 'com.github.bancolombia:aws-secrets-manager-async:4.4.34'
+    implementation 'software.amazon.awssdk:sts'
+	implementation project(':metrics')
 	implementation project(':password-encoder')
 	implementation project(':jwt')
 	implementation project(':logger')

--- a/applications/app-service/src/main/java/co/com/pragma/crediya/config/SecretsConfig.java
+++ b/applications/app-service/src/main/java/co/com/pragma/crediya/config/SecretsConfig.java
@@ -1,0 +1,44 @@
+package co.com.pragma.crediya.config;
+
+import co.com.bancolombia.secretsmanager.api.GenericManagerAsync;
+import co.com.bancolombia.secretsmanager.api.exceptions.SecretException;
+import co.com.bancolombia.secretsmanager.config.AWSSecretsManagerConfig;
+import co.com.bancolombia.secretsmanager.connector.AWSSecretManagerConnectorAsync;
+import co.com.pragma.crediya.jwt.config.JwtProperties;
+import co.com.pragma.crediya.r2dbc.config.PostgresqlConnectionProperties;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.regions.Region;
+
+@Configuration
+public class SecretsConfig {
+
+    @Bean
+    public GenericManagerAsync getSecretManager(@Value("${aws.region}") String region) {
+        return new AWSSecretManagerConnectorAsync(getConfig(region));
+    }
+
+    private AWSSecretsManagerConfig getConfig(String region) {
+        return AWSSecretsManagerConfig.builder()
+                .region(Region.of(region))
+                .cacheSize(5)
+                .cacheSeconds(3600)
+                .build();
+    }
+
+    @Bean
+    public PostgresqlConnectionProperties postgresqlConnectionProperties(
+            final GenericManagerAsync connector, @Value("${aws.rds.postgres.secretName}") String secretName) throws SecretException {
+        return connector.getSecret(secretName, PostgresqlConnectionProperties.class)
+                .block();
+    }
+
+    @Bean
+    public JwtProperties jwtProperties(
+            final GenericManagerAsync connector, @Value("${aws.jwt.secretName}") String secretName) throws SecretException {
+        return connector.getSecret(secretName, JwtProperties.class)
+                .block();
+    }
+
+}

--- a/applications/app-service/src/main/resources/application-dev.yaml
+++ b/applications/app-service/src/main/resources/application-dev.yaml
@@ -1,22 +1,17 @@
 spring:
-  r2dbc:
-    url: jdbc:postgresql://${R2DBC_HOST}:${R2DBC_PORT}/${R2DBC_DATABASE}
-    username: ${R2DBC_USERNAME}
-    password: ${R2DBC_PASSWORD}
-    properties:
-      schema: ${R2DBC_SCHEMA}
-
   flyway:
     url: jdbc:postgresql://${R2DBC_HOST}:${R2DBC_PORT}/${R2DBC_DATABASE}
     user: ${R2DBC_USERNAME}
     password: ${R2DBC_PASSWORD}
     default-schema: ${R2DBC_SCHEMA}
 
-application:
-  security:
-    jwt:
-      expiration: 3600000
-      secret-key: ${JWT_SECRET_KEY}
+aws:
+  region: "${AWS_REGION}"
+  rds:
+    postgres:
+      secretName: "${AWS_RDS_POSTGRES_SECRET_NAME}"
+  jwt:
+    secretName: "${AWS_JWT_SECRET_NAME}"
 
 logging:
   level:

--- a/applications/app-service/src/main/resources/application-local.yaml
+++ b/applications/app-service/src/main/resources/application-local.yaml
@@ -1,11 +1,4 @@
 spring:
-  r2dbc:
-    url: r2dbc:postgresql://${R2DBC_HOST}:${R2DBC_PORT}/${R2DBC_DATABASE}
-    username: ${R2DBC_USERNAME}
-    password: ${R2DBC_PASSWORD}
-    properties:
-      schema: ${R2DBC_SCHEMA}
-
   flyway:
     url: jdbc:postgresql://${R2DBC_HOST}:${R2DBC_PORT}/${R2DBC_DATABASE}
     user: ${R2DBC_USERNAME}
@@ -14,20 +7,13 @@ spring:
     locations: classpath:db/migration
     enabled: true
 
-adapters:
-  r2dbc:
-    host: ${R2DBC_HOST}
-    port: ${R2DBC_PORT}
-    database: ${R2DBC_DATABASE}
-    schema: ${R2DBC_SCHEMA}
-    username: ${R2DBC_USERNAME}
-    password: ${R2DBC_PASSWORD}
-
-application:
-  security:
-    jwt:
-      expiration: 7200000
-      secret-key: ${JWT_SECRET_KEY}
+aws:
+  region: "${AWS_REGION}"
+  rds:
+    postgres:
+      secretName: "${AWS_RDS_POSTGRES_SECRET_NAME}"
+  jwt:
+    secretName: "${AWS_JWT_SECRET_NAME}"
 
 logging:
   level:

--- a/applications/app-service/src/main/resources/application-prod.yaml
+++ b/applications/app-service/src/main/resources/application-prod.yaml
@@ -1,23 +1,18 @@
 spring:
-  r2dbc:
-    url: jdbc:postgresql://${R2DBC_HOST}:${R2DBC_PORT}/${R2DBC_DATABASE}
-    username: ${R2DBC_USERNAME}
-    password: ${R2DBC_PASSWORD}
-    properties:
-      schema: ${R2DBC_SCHEMA}
-
   flyway:
     url: jdbc:postgresql://${R2DBC_HOST}:${R2DBC_PORT}/${R2DBC_DATABASE}
     user: ${R2DBC_USERNAME}
     password: ${R2DBC_PASSWORD}
     default-schema: ${R2DBC_SCHEMA}
 
-application:
-  security:
-    jwt:
-      expiration: 1800000
-      secret-key: ${JWT_SECRET_KEY}
+aws:
+  region: "${AWS_REGION}"
+  rds:
+    postgres:
+      secretName: "${AWS_RDS_POSTGRES_SECRET_NAME}"
+  jwt:
+    secretName: "${AWS_JWT_SECRET_NAME}"
 
 logging:
   level:
-    root: WARN
+    root: INFO

--- a/applications/app-service/src/main/resources/application.yaml
+++ b/applications/app-service/src/main/resources/application.yaml
@@ -22,7 +22,7 @@ management:
         enabled: true
 
 cors:
-  allowed-origins: ${CORS_ALLOWED_ORIGINS}
+  allowed-origins: "${CORS_ALLOWED_ORIGINS}"
 
 springdoc:
   swagger-ui:

--- a/infrastructure/driven-adapters/jwt/src/main/java/co/com/pragma/crediya/jwt/JwtProviderAdapter.java
+++ b/infrastructure/driven-adapters/jwt/src/main/java/co/com/pragma/crediya/jwt/JwtProviderAdapter.java
@@ -24,7 +24,7 @@ public class JwtProviderAdapter implements JwtProviderPort {
 
     @Override
     public String generateToken(User user) {
-        return buildToken(user, properties.getExpiration());
+        return buildToken(user, properties.expiration());
     }
 
     @Override
@@ -55,7 +55,7 @@ public class JwtProviderAdapter implements JwtProviderPort {
     }
 
     private SecretKey getSecretKey() {
-        String secretKey = properties.getSecretKey();
+        String secretKey = properties.secretKey();
         byte[] keyBytes = Decoders.BASE64.decode(secretKey);
 
         return Keys.hmacShaKeyFor(keyBytes);

--- a/infrastructure/driven-adapters/jwt/src/main/java/co/com/pragma/crediya/jwt/config/JwtProperties.java
+++ b/infrastructure/driven-adapters/jwt/src/main/java/co/com/pragma/crediya/jwt/config/JwtProperties.java
@@ -1,18 +1,4 @@
 package co.com.pragma.crediya.jwt.config;
 
-import lombok.Getter;
-import lombok.Setter;
-import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.context.annotation.Configuration;
-
-@Getter
-@Setter
-@Configuration
-@ConfigurationProperties(prefix = "application.security.jwt")
-public class JwtProperties {
-
-    private String secretKey;
-
-    private long expiration;
-
+public record JwtProperties(String secretKey, long expiration) {
 }

--- a/infrastructure/driven-adapters/jwt/src/test/java/co/com/pragma/crediya/jwt/JwtProviderAdapterTest.java
+++ b/infrastructure/driven-adapters/jwt/src/test/java/co/com/pragma/crediya/jwt/JwtProviderAdapterTest.java
@@ -24,9 +24,7 @@ class JwtProviderAdapterTest {
 
     @BeforeEach
     void setUp() {
-        JwtProperties properties = new JwtProperties();
-        properties.setSecretKey("q/MbiTiaKL9wCSeISqOlOQvDjg7s+xmYRtNhYbq7T3A=");
-        properties.setExpiration(10000L);
+        JwtProperties properties = new JwtProperties("q/MbiTiaKL9wCSeISqOlOQvDjg7s+xmYRtNhYbq7T3A=", 60000L);
 
         adapter = new JwtProviderAdapter(properties);
 

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/pragma/crediya/r2dbc/config/PostgreSQLConnectionPool.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/pragma/crediya/r2dbc/config/PostgreSQLConnectionPool.java
@@ -1,46 +1,45 @@
 package co.com.pragma.crediya.r2dbc.config;
 
-import java.time.Duration;
-
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-
 import io.r2dbc.pool.ConnectionPool;
 import io.r2dbc.pool.ConnectionPoolConfiguration;
 import io.r2dbc.postgresql.PostgresqlConnectionConfiguration;
 import io.r2dbc.postgresql.PostgresqlConnectionFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Duration;
 
 @Configuration
 public class PostgreSQLConnectionPool {
 
-	public static final int INITIAL_SIZE = 12;
+    public static final int INITIAL_SIZE = 12;
 
-	public static final int MAX_SIZE = 15;
+    public static final int MAX_SIZE = 15;
 
-	public static final int MAX_IDLE_TIME = 30;
+    public static final int MAX_IDLE_TIME = 30;
 
-	public static final int DEFAULT_PORT = 5432;
+    @Bean
+    public ConnectionPool getConnectionConfig(PostgresqlConnectionProperties properties) {
+        PostgresqlConnectionConfiguration dbConfiguration = PostgresqlConnectionConfiguration.builder()
+                .host(properties.host())
+                .port(properties.port())
+                .database(properties.database())
+                .schema(properties.schema())
+                .username(properties.username())
+                .password(properties.password())
+                .sslMode(properties.sslMode())
+                .build();
 
-	@Bean
-	public ConnectionPool getConnectionConfig(PostgresqlConnectionProperties properties) {
-		PostgresqlConnectionConfiguration dbConfiguration = PostgresqlConnectionConfiguration.builder()
-				.host(properties.host())
-				.port(properties.port())
-				.database(properties.database())
-				.schema(properties.schema())
-				.username(properties.username())
-				.password(properties.password())
-				.build();
+        ConnectionPoolConfiguration poolConfiguration = ConnectionPoolConfiguration.builder()
+                .connectionFactory(new PostgresqlConnectionFactory(dbConfiguration))
+                .name("api-postgres-connection-pool")
+                .initialSize(INITIAL_SIZE)
+                .maxSize(MAX_SIZE)
+                .maxIdleTime(Duration.ofMinutes(MAX_IDLE_TIME))
+                .validationQuery("SELECT 1")
+                .build();
 
-		ConnectionPoolConfiguration poolConfiguration = ConnectionPoolConfiguration.builder()
-				.connectionFactory(new PostgresqlConnectionFactory(dbConfiguration))
-				.name("api-postgres-connection-pool")
-				.initialSize(INITIAL_SIZE)
-				.maxSize(MAX_SIZE)
-				.maxIdleTime(Duration.ofMinutes(MAX_IDLE_TIME))
-				.validationQuery("SELECT 1")
-				.build();
+        return new ConnectionPool(poolConfiguration);
+    }
 
-		return new ConnectionPool(poolConfiguration);
-	}
 }

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/pragma/crediya/r2dbc/config/PostgresqlConnectionProperties.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/pragma/crediya/r2dbc/config/PostgresqlConnectionProperties.java
@@ -1,13 +1,13 @@
 package co.com.pragma.crediya.r2dbc.config;
 
-import org.springframework.boot.context.properties.ConfigurationProperties;
+import io.r2dbc.postgresql.client.SSLMode;
 
-@ConfigurationProperties(prefix = "adapters.r2dbc")
 public record PostgresqlConnectionProperties(
-		String host,
-		Integer port,
-		String database,
-		String schema,
-		String username,
-		String password) {
+        String host,
+        Integer port,
+        String database,
+        String schema,
+        String username,
+        String password,
+        SSLMode sslMode) {
 }

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/test/java/co/com/pragma/crediya/r2dbc/config/PostgreSQLConnectionPoolTest.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/test/java/co/com/pragma/crediya/r2dbc/config/PostgreSQLConnectionPoolTest.java
@@ -1,5 +1,6 @@
 package co.com.pragma.crediya.r2dbc.config;
 
+import io.r2dbc.postgresql.client.SSLMode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -28,10 +29,12 @@ class PostgreSQLConnectionPoolTest {
         when(properties.schema()).thenReturn("schema");
         when(properties.username()).thenReturn("username");
         when(properties.password()).thenReturn("password");
+        when(properties.sslMode()).thenReturn(SSLMode.DISABLE);
     }
 
     @Test
     void getConnectionConfigSuccess() {
         assertNotNull(connectionPool.getConnectionConfig(properties));
     }
+
 }

--- a/infrastructure/helpers/metrics/build.gradle
+++ b/infrastructure/helpers/metrics/build.gradle
@@ -1,0 +1,5 @@
+dependencies {
+    implementation 'org.springframework:spring-context'
+    implementation 'io.micrometer:micrometer-core'
+    implementation 'software.amazon.awssdk:metrics-spi'
+}

--- a/infrastructure/helpers/metrics/src/main/java/co/com/pragma/crediya/metrics/aws/MicrometerMetricPublisher.java
+++ b/infrastructure/helpers/metrics/src/main/java/co/com/pragma/crediya/metrics/aws/MicrometerMetricPublisher.java
@@ -1,0 +1,50 @@
+package co.com.pragma.crediya.metrics.aws;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.metrics.MetricCollection;
+import software.amazon.awssdk.metrics.MetricPublisher;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+
+@Component
+@AllArgsConstructor
+public class MicrometerMetricPublisher implements MetricPublisher {
+
+    private final ExecutorService service;
+
+    private final MeterRegistry registry;
+
+    @Override
+    public void publish(MetricCollection metricCollection) {
+        service.submit(() -> {
+            List<Tag> tags = buildTags(metricCollection);
+            metricCollection.stream()
+                    .filter(metricRecord -> metricRecord.value() instanceof Duration || metricRecord.value() instanceof Integer)
+                    .forEach(metricRecord -> {
+                        if (metricRecord.value() instanceof Duration) {
+                            registry.timer(metricRecord.metric().name(), tags).record((Duration) metricRecord.value());
+                        } else if (metricRecord.value() instanceof Integer) {
+                            registry.counter(metricRecord.metric().name(), tags).increment((Integer) metricRecord.value());
+                        }
+                    });
+        });
+    }
+
+    @Override
+    public void close() {
+        // Something
+    }
+
+    private List<Tag> buildTags(MetricCollection metricCollection) {
+        return metricCollection.stream()
+                .filter(metricRecord -> metricRecord.value() instanceof String || metricRecord.value() instanceof Boolean)
+                .map(metricRecord -> Tag.of(metricRecord.metric().name(), metricRecord.value().toString()))
+                .toList();
+    }
+
+}

--- a/infrastructure/helpers/metrics/src/main/java/co/com/pragma/crediya/metrics/aws/config/MetricsConfig.java
+++ b/infrastructure/helpers/metrics/src/main/java/co/com/pragma/crediya/metrics/aws/config/MetricsConfig.java
@@ -1,0 +1,19 @@
+package co.com.pragma.crediya.metrics.aws.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+@Configuration
+public class MetricsConfig {
+
+    public static final String AWS_METRICS_EXECUTOR = "awsMetricsExecutor";
+
+    @Bean(name = AWS_METRICS_EXECUTOR, destroyMethod = "shutdown")
+    public ExecutorService awsMetricsExecutor() {
+        return Executors.newFixedThreadPool(10);
+    }
+
+}

--- a/infrastructure/helpers/metrics/src/test/java/co/com/pragma/crediya/metrics/aws/MicrometerMetricPublisherTest.java
+++ b/infrastructure/helpers/metrics/src/test/java/co/com/pragma/crediya/metrics/aws/MicrometerMetricPublisherTest.java
@@ -1,0 +1,128 @@
+package co.com.pragma.crediya.metrics.aws;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.metrics.MetricCollection;
+import software.amazon.awssdk.metrics.MetricRecord;
+import software.amazon.awssdk.metrics.SdkMetric;
+
+import java.time.Duration;
+import java.util.concurrent.ExecutorService;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MicrometerMetricPublisherTest {
+
+    @Mock
+    private ExecutorService mockExecutor;
+
+    @Mock
+    private MetricCollection mockMetricCollection;
+
+    @Mock
+    private MetricRecord<Duration> apiCallDurationRecord;
+
+    @Mock
+    private MetricRecord<Integer> retryAttemptsRecord;
+
+    @Mock
+    private MetricRecord<String> serviceIdRecord;
+
+    @Mock
+    private MetricRecord<Boolean> successfulRecord;
+
+    @Mock
+    private SdkMetric<Duration> apiCallDurationMetric;
+
+    @Mock
+    private SdkMetric<Integer> retryAttemptsMetric;
+
+    @Mock
+    private SdkMetric<String> serviceIdMetric;
+
+    @Mock
+    private SdkMetric<Boolean> successfulMetric;
+
+    private MeterRegistry meterRegistry;
+
+    private MicrometerMetricPublisher publisher;
+
+    public static final String API_CALL_DURATION = "ApiCallDuration";
+
+    public static final String RETRY_COUNT = "RetryCount";
+
+    public static final String SQS = "SQS";
+
+    public static final String SERVICE_ID = "ServiceId";
+
+    public static final String SUCCESSFUL = "Successful";
+
+    public static final String TRUE = "true";
+
+    @BeforeEach
+    void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+
+        publisher = new MicrometerMetricPublisher(mockExecutor, meterRegistry);
+    }
+
+    @Test
+    @DisplayName("Publish AWS SDK metrics to Micrometer registry with correct timers, counters and tags")
+    void publish_shouldConvertAndRecordMetrics() {
+        when(apiCallDurationRecord.value()).thenReturn(Duration.ofMillis(150));
+        when(apiCallDurationRecord.metric()).thenReturn(apiCallDurationMetric);
+        when(apiCallDurationMetric.name()).thenReturn(API_CALL_DURATION);
+
+        when(retryAttemptsRecord.value()).thenReturn(2);
+        when(retryAttemptsRecord.metric()).thenReturn(retryAttemptsMetric);
+        when(retryAttemptsMetric.name()).thenReturn(RETRY_COUNT);
+
+        when(serviceIdRecord.value()).thenReturn(SQS);
+        when(serviceIdRecord.metric()).thenReturn(serviceIdMetric);
+        when(serviceIdMetric.name()).thenReturn(SERVICE_ID);
+
+        when(successfulRecord.value()).thenReturn(true);
+        when(successfulRecord.metric()).thenReturn(successfulMetric);
+        when(successfulMetric.name()).thenReturn(SUCCESSFUL);
+
+        when(mockMetricCollection.stream()).thenAnswer(invocation -> Stream.of(apiCallDurationRecord, retryAttemptsRecord, serviceIdRecord, successfulRecord));
+
+        ArgumentCaptor<Runnable> runnableCaptor = ArgumentCaptor.forClass(Runnable.class);
+
+        publisher.publish(mockMetricCollection);
+        verify(mockExecutor).submit(runnableCaptor.capture());
+        runnableCaptor.getValue().run();
+
+        Timer apiCallTimer = meterRegistry.find(API_CALL_DURATION).timer();
+        assertThat(apiCallTimer).isNotNull();
+        assertThat(apiCallTimer.count()).isEqualTo(1);
+        assertThat(apiCallTimer.totalTime(java.util.concurrent.TimeUnit.MILLISECONDS)).isEqualTo(150);
+        assertThat(apiCallTimer.getId().getTags()).containsExactlyInAnyOrder(
+                Tag.of(SERVICE_ID, SQS),
+                Tag.of(SUCCESSFUL, TRUE)
+        );
+
+        Counter retryCounter = meterRegistry.find(RETRY_COUNT).counter();
+        assertThat(retryCounter).isNotNull();
+        assertThat(retryCounter.count()).isEqualTo(2);
+        assertThat(retryCounter.getId().getTags()).containsExactlyInAnyOrder(
+                Tag.of(SERVICE_ID, SQS),
+                Tag.of(SUCCESSFUL, TRUE)
+        );
+    }
+
+}

--- a/infrastructure/helpers/metrics/src/test/java/co/com/pragma/crediya/metrics/aws/config/MetricsConfigTest.java
+++ b/infrastructure/helpers/metrics/src/test/java/co/com/pragma/crediya/metrics/aws/config/MetricsConfigTest.java
@@ -1,0 +1,24 @@
+package co.com.pragma.crediya.metrics.aws.config;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+import java.util.concurrent.ExecutorService;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+class MetricsConfigTest {
+
+    @Test
+    void awsMetricsExecutorBean_shouldBeCreated() {
+        try (AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(MetricsConfig.class)) {
+            ExecutorService executorService = (ExecutorService) context.getBean(MetricsConfig.AWS_METRICS_EXECUTOR);
+            assertThat(executorService).isNotNull();
+            assertThat(executorService.isShutdown()).isFalse();
+        }
+    }
+
+}

--- a/main.gradle
+++ b/main.gradle
@@ -28,6 +28,7 @@ subprojects {
     }
 
     dependencies {
+		implementation platform('software.amazon.awssdk:bom:2.32.13')
         implementation 'io.projectreactor:reactor-core'
         implementation 'io.projectreactor.addons:reactor-extra'
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -30,3 +30,5 @@ include ':jwt'
 project(':jwt').projectDir = file('./infrastructure/driven-adapters/jwt')
 include ':password-encoder'
 project(':password-encoder').projectDir = file('./infrastructure/driven-adapters/password-encoder')
+include ':metrics'
+project(':metrics').projectDir = file('./infrastructure/helpers/metrics')


### PR DESCRIPTION
- Add AWS Secrets Manager
- Replace local JWT and R2DBC credentials with AWS secret references
- Update application-dev, local, and prod YAMLs to use AWS secret names
- Update PostgresqlConnectionProperties to include SSLMode