### PR TITLE
feat(auth): apply unified base path for auth module

### DIFF
--- a/applications/app-service/src/main/resources/application.yaml
+++ b/applications/app-service/src/main/resources/application.yaml
@@ -14,6 +14,7 @@ server:
 management:
   endpoints:
     web:
+      base-path: "/api/v1/auth/actuator"
       exposure:
         include: "health,prometheus"
   endpoint:
@@ -25,5 +26,7 @@ cors:
   allowed-origins: "${CORS_ALLOWED_ORIGINS}"
 
 springdoc:
+  api-docs:
+    path: "/api/v1/auth/api-docs"
   swagger-ui:
-    path: /swagger-ui.html
+    path: "/api/v1/auth/swagger-ui.html"

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/constants/ApiConstants.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/constants/ApiConstants.java
@@ -9,21 +9,23 @@ public final class ApiConstants {
 
     public static final String API_V1 = "/api/v1";
 
-    public static final String LOGIN_PATH = API_V1 + "/login";
+    public static final String BASE_PATH = API_V1 + "/auth";
 
-    public static final String USERS_PATH = API_V1 + "/users";
+    public static final String LOGIN_PATH = BASE_PATH + "/login";
+
+    public static final String USERS_PATH = BASE_PATH + "/users";
 
     public static final String USERS_SEARCH_PATH = USERS_PATH + "/search";
 
     public static final String USER_BY_IDENTIFICATION_NUMBER_PATH = USERS_PATH + "/{" + UserFieldNames.IDENTIFICATION_NUMBER + "}";
 
     public static final String[] PUBLIC_PATTERNS = {
-            "/actuator",
-            "/actuator/health",
-            "/actuator/prometheus",
-            "/v3/api-docs/**",
-            "/swagger-ui/**",
-            "/swagger-ui.html",
+            BASE_PATH + "/actuator",
+            BASE_PATH + "/actuator/health",
+            BASE_PATH + "/actuator/prometheus",
+            BASE_PATH + "/swagger-ui.html",
+            BASE_PATH + "/swagger-ui/**",
+            BASE_PATH + "/api-docs/**",
             LOGIN_PATH + "/**"
     };
 


### PR DESCRIPTION
- Define BASE_PATH constant (/api/v1/auth) in ApiConstants
- Update LOGIN_PATH and USERS_PATH to derive from BASE_PATH
- Adjust PUBLIC_PATTERNS to reference BASE_PATH for actuator, swagger and api-docs endpoints
- Configure application.yaml to use BASE_PATH for actuator, OpenAPI docs and Swagger UI